### PR TITLE
Potential fix for code scanning alert no. 30: DOM text reinterpreted as HTML

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -7121,10 +7121,15 @@ function buildDownloaderCombined(source){
     }
 }
 function buildMetadata(array, source){
-	var metadata = '';
-	var genres = '';
-	var actors = '';
-	var rating = '<div class="col-xs-2 p-10"></div>';
+    // Whitelist the source to allowed values only to prevent XSS
+    var allowedSources = ['plex', 'emby', 'jellyfin'];
+    if (allowedSources.indexOf(source) === -1) {
+        source = 'plex';
+    }
+    var metadata = '';
+    var genres = '';
+    var actors = '';
+    var rating = '<div class="col-xs-2 p-10"></div>';
     var sourceIcon = (source === 'jellyfin') ? 'fish' : source;
 	$.each(array.content, function(i,v) {
 		var hasActor = (typeof v.metadata.actors !== 'string') ? true : false;


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Organizr-docker/security/code-scanning/30](https://github.com/GitTimeraider/Organizr-docker/security/code-scanning/30)

To fix the problem, any outputs that interpolate `source` (derived from a DOM attribute) into HTML should sanitize or escape it before use, especially before writing it as HTML via `.html(...)`. Since `source` is only interpolated into CSS class names (e.g., `bg-...`, `mdi-...`), ensure the value is strictly limited to a known set or, at minimum, safely escaped to prevent HTML/script injection.

The best solution is a combination of:
- Enforcing a whitelist for `source` (since there are only a limited set of valid sources)
- (Optionally) Using an escaping helper for class names

Required changes:
- In `buildMetadata` (js/functions.js), right at the start, enforce that `source` is a valid known value (e.g., 'plex', 'emby', 'jellyfin'), and otherwise default to a safe value (such as 'plex').
- Use the sanitized `source` for all interpolations within that function.
- No changes are required outside of `js/functions.js` and only the `buildMetadata` function will be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
