### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -1,5 +1,13 @@
 /*jslint browser: true*/
 /*global $, jQuery, alert*/
+
+// Allow only http(s) or root-relative URLs
+function isSafeUrl(url) {
+    if (typeof url !== "string") return false;
+    // allow http://, https://, // (protocol-relative), or root-relative /
+    return /^(https?:\/\/|\/\/|\/(?!\/))[^ \r\n]+$/i.test(url);
+}
+
 var idleTime = 0;
 var hasCookie = false;
 var loginAttempts = 0;
@@ -1366,9 +1374,15 @@ $(document).on("click", ".openTab", function(e) {
         var tabName = $(this).attr("data-tab-name");
         var container = $("#container-"+tabName);
         var activeFrame = container.children('iframe');
+        var rawUrl = $(this).attr("data-url");
         if(activeFrame.length === 1){
             $('#menu-'+tabName+' a').trigger("click");
-            activeFrame.attr("src", $(this).attr("data-url"));
+            if (isSafeUrl(rawUrl)) {
+                activeFrame.attr("src", rawUrl);
+            } else {
+                console.warn("Blocked unsafe URL in data-url:", rawUrl);
+                // Optionally, show error to user here
+            }
         }else{
             container.attr("data-url", $(this).attr("data-url"));
             $('#menu-'+tabName+' a').trigger("click");


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Organizr-docker/security/code-scanning/29](https://github.com/GitTimeraider/Organizr-docker/security/code-scanning/29)

**General fix:**  
Sanitize the value extracted from the `data-url` attribute before using it to set the `iframe`'s `src` attribute, ensuring that it is a valid, allowed URL (for example, starts with "http://" or "https://", or is a relative path). Never allow scripting (e.g., "javascript:", "data:") or other unwanted schemes.

**Best fix details:**  
- In the file `js/custom.js`, locate the code in the `.openTab` handler, specifically where `activeFrame.attr("src", $(this).attr("data-url"));` is used (line 1371).
- Before setting the `src` attribute, validate the URL: allow only URLs that start with "http://", "https://", or "/".
- If the URL is not valid, do not set the attribute or handle the case appropriately (could log or show an error).
- No new external libraries are necessary; use a simple RegExp to validate the URL.
- Apply the same sanitization logic wherever the data-url is used to set an iframe’s `src` if repeated elsewhere (the snippet shows a second case in line 1373, but that is setting an attribute on a div, NOT on the iframe itself, so only 1371 needs fixing).
- All changes are confined to this code block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
